### PR TITLE
Clean filename before creating temporary files

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -642,6 +642,7 @@ function turnitintooltwo_tempfile(array $filename, $suffix) {
 
     $filename = implode('_', $filename);
     $filename = str_replace(' ', '_', $filename);
+    $filename = clean_param($filename, PARAM_FILE);
 
     $tempdir = make_temp_directory('turnitintooltwo');
 


### PR DESCRIPTION
Try submitting a file, and putting a slash in the "Submission Title" box - it will throw an "invalid dataroot permissions" error.
This may also be considered a possible security issue, as ../../../, etc can also be used